### PR TITLE
chore: Rename more atmo and runnable strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Runnable Templates
+# Templates
 
-This repo is the basis for creating your own Runnable templates for Reactr, Atmo, and Suborbital Compute. TypeScript/AssemblyScript, Rust, and Swift are supported.
+This repo is the basis for creating your own modulee templates for E2Core and Suborbital Extension Engine.
 
 To get started, fork this repo into your own organization. It must be public.
 
-Next, clone your fork and edit `templates/assemblyscript/src/custom.ts` and `templates/assemblyscript/src/lib.ts` to change the template that will be used to create new Runnables. If you're a Flight Deck user, `lib.ts` is what will be used for all new functions when your users access the code editor.
+Next, clone your fork and edit `templates/assemblyscript/src/custom.ts` and `templates/assemblyscript/src/lib.ts` to change the template that will be used to create new modules. If you're a SE2 user, `lib.ts` is what will be used for all new functions when your users access the code editor.
 
-Optionally, if you'd like to provide a custom wrapper around the Suborbital core library (i.e. allow your users to import `@acmeco/acmeco` instead of `@suborbital/suborbital`), then edit `library/assemblyscript/package.json` to replace all instances of `acmeco` with your desired name, and then publish the library to NPM. Add your custom library as an import in `templates/assemblyscript/package.json.tmpl` so your custom Runnables can use it.
+Optionally, if you'd like to provide a custom wrapper around the Suborbital core library (i.e. allow your users to import `@acmeco/acmeco` instead of `@suborbital/suborbital`), then edit `library/assemblyscript/package.json` to replace all instances of `acmeco` with your desired name, and then publish the library to NPM. Add your custom library as an import in `templates/assemblyscript/package.json.tmpl` so your custom modules can use it.
 
-You can now use your forked repo as a target for templates, for example `subo create runnable custom-func --repo acmeco/function-templates --lang typescript --update-templates`
+You can now use your forked repo as a target for templates, for example `subo create module custom-func --repo acmeco/function-templates --lang typescript --update-templates`

--- a/library/assemblyscript/package.json
+++ b/library/assemblyscript/package.json
@@ -16,7 +16,7 @@
     "wasm",
     "acmeco",
     "function-templates",
-    "atmo",
+    "e2core",
     "cloud",
     "native",
     "assemblyscript",

--- a/templates/k8s/e2core-deployment.yaml.tmpl
+++ b/templates/k8s/e2core-deployment.yaml.tmpl
@@ -5,38 +5,38 @@ metadata:
   name: {{ .Identifier }}-deployment
   namespace: suborbital
   labels:
-    app: atmo
+    app: e2core
 
 spec:
   replicas: 1
 
   selector:
     matchLabels:
-      app: atmo
+      app: e2core
 
   template:
     metadata:
       labels:
-        app: atmo
+        app: e2core
 
     spec:
       containers:
-        - name: atmo
+        - name: e2core
           image: {{ .ImageName }}
-          command: ["atmo"]
+          command: ["e2core"]
 
           ports:
             - containerPort: 8080
             - containerPort: 443
 
           env:
-            - name: ATMO_DOMAIN
+            - name: E2CORE_DOMAIN
               value: {{ .Domain }}
-            
-            - name: ATMO_HTTP_PORT
+
+            - name: E2CORE_HTTP_PORT
               value: "8080"
-            
-            - name: ATMO_LOG_LEVEL
+
+            - name: E2CORE_LOG_LEVEL
               value: "info"
 
             - name: APP_VERSION

--- a/templates/k8s/e2core-svc.yaml.tmpl
+++ b/templates/k8s/e2core-svc.yaml.tmpl
@@ -7,7 +7,7 @@ metadata:
 
 spec:
   selector:
-    app: atmo
+    app: e2core
 
   ports:
     - port: 80

--- a/templates/project/Directive.yaml.tmpl
+++ b/templates/project/Directive.yaml.tmpl
@@ -1,6 +1,6 @@
 # the Directive is a complete description of your application, including all of its business logic.
 # appVersion should be updated for each new deployment of your app.
-# atmoVersion declares which version of Atmo is used for the `subo dev` command.
+# e2coreVersion declares which version of E2Core is used for the `subo dev` command.
 
 identifier: {{ .Environment }}.{{ .Name }}
 appVersion: v0.1.0

--- a/templates/se2-docker/docker-compose.yml.tmpl
+++ b/templates/se2-docker/docker-compose.yml.tmpl
@@ -9,7 +9,7 @@ services:
       SE2_LOG_LEVEL: info
       SE2_HTTP_PORT: 8081
     env_file:
-      - SCC.env
+      - SE2.env
     ports:
       - "8081:8081"
     networks:


### PR DESCRIPTION
Removes additional references in the templates to Atmo and Runnables in
favour of E2Core and modules.
