### PR TITLE
fix: Fix tinygo-handler .manifest.json lib file

### DIFF
--- a/.manifest.json
+++ b/.manifest.json
@@ -28,7 +28,7 @@
         "tinygo-handler": {
             "path": "templates/tinygo-handler",
             "lang": "tinygo",
-            "lib": "main.go.tmpl"
+            "lib": "handler.go.tmpl"
         }
     }
 }


### PR DESCRIPTION
It was pointing at the wrong file!