### PR TITLE
Use template vars for E2Core and SE2

### DIFF
--- a/templates/project/Directive.yaml.tmpl
+++ b/templates/project/Directive.yaml.tmpl
@@ -1,6 +1,6 @@
 # the Directive is a complete description of your application, including all of its business logic.
 # appVersion should be updated for each new deployment of your app.
-# e2coreVersion declares which version of E2Core is used for the `subo dev` command.
+# RuntimeVersion declares which version of E2Core is used for the `subo dev` command.
 
 identifier: {{ .Environment }}.{{ .Name }}
 appVersion: v0.1.0

--- a/templates/se2-docker/docker-compose.yml.tmpl
+++ b/templates/se2-docker/docker-compose.yml.tmpl
@@ -1,7 +1,7 @@
 version: '3'
 services:
   se2-controlplane:
-    image: suborbital/se2-controlplane:{{ .SE2Version }}
+    image: suborbital/se2-controlplane:{{ .SE2Tag }}
     command: controlplane
     volumes:
       - ./:/home/se2
@@ -16,7 +16,7 @@ services:
       - se2
 
   se2-builder:
-    image: suborbital/se2-builder:{{ .SE2Version }}
+    image: suborbital/se2-builder:{{ .SE2Tag }}
     command: builder
     volumes:
       - ./:/home/se2
@@ -29,7 +29,7 @@ services:
       - se2
 
   e2core:
-    image: suborbital/e2core:v0.5.0
+    image: suborbital/e2core:{{ .E2CoreTag }}
     command: e2core start
     depends_on:
       - se2-controlplane

--- a/templates/se2-k8s/.suborbital/e2core-deployment.yaml.tmpl
+++ b/templates/se2-k8s/.suborbital/e2core-deployment.yaml.tmpl
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: e2core
-          image: suborbital/e2core:v0.5.0
+          image: suborbital/e2core:{{ .E2CoreTag }}
           command: ["e2core"]
           args: ["start"]
 

--- a/templates/se2-k8s/.suborbital/se2-controlplane-deployment.yaml.tmpl
+++ b/templates/se2-k8s/.suborbital/se2-controlplane-deployment.yaml.tmpl
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: controlplane
-          image: suborbital/se2-controlplane:{{ .SE2Version }}
+          image: suborbital/se2-controlplane:{{ .SE2Tag }}
           command: ["controlplane"]
 
           ports:
@@ -46,7 +46,7 @@ spec:
               readOnly: true
 
         - name: builder
-          image: suborbital/se2-builder:{{ .SE2Version }}
+          image: suborbital/se2-builder:{{ .SE2Tag }}
           command: ["builder"]
 
           ports:


### PR DESCRIPTION
- Renames `SE2Verison` to `SE2Tag` to make it clear what is being updated (as it represents the entire tag which could be a version or "latest", etc)
- Templates `E2CoreTag` similar to `SE2Tag`, ensuring that subo controls the version directly and not this template